### PR TITLE
Don't throw error if npm package has `svelte` key

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,13 +54,8 @@ module.exports = new Transformer({
     );
     let contents = {};
     if (conf) {
-      contents = conf.contents;
-      if (typeof contents !== 'object') {
-        throw new ThrowableDiagnostic({
-          diagnostic: {
-            message: 'Svelte config should be an object.',
-          },
-        });
+      if (typeof contents == 'object') {
+        contents = conf.contents;
       }
       if (conf.filePath.endsWith('.js')) {
         config.invalidateOnStartup();


### PR DESCRIPTION
I encountered this problem when using the `svelte-spa-router` which has `svelte` key here https://github.com/ItalyPaleAle/svelte-spa-router/blob/916347dbef1eb429332bca8375dae549169e665a/package.json#L6

This results in the `config.contents` being a string and throwing the `ThrowableDiagnostic` and a failing build.

Not sure if we really need to throw this error. My simplistic solution is to only set `contents` to `conf.contents` if it is an object. There may be a more elegant solution but this at least allows me to build my project.

Thanks